### PR TITLE
ci(actions): upgrade to Node.js 24 compatible action versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,15 +13,15 @@ jobs:
       matrix:
         node-version: ['20', '22', '24', '25']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           check-latest: true
       - name: Cache Node.js modules
         id: yarn-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}-${{ matrix.node-version }}

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -9,8 +9,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -13,15 +13,15 @@ jobs:
       matrix:
         node-version: ['24']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           check-latest: true
       - name: Cache Node.js modules
         id: yarn-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}-${{ matrix.node-version }}


### PR DESCRIPTION
## Summary

- Replace `actions/checkout@v4` with `@v5` across all four workflow files
- Replace `actions/setup-node@v2`/`@v4` with `@v6` across all workflow files
- Replace `actions/cache@v4` with `@v5` in `nodejs.yml` and `prettier.yml`
- Also modernises `npm-release.yml` from legacy `@v2` pins to current versions

All three actions previously ran on the Node.js 20 runtime, which GitHub is deprecating and forcing to Node.js 24 on **June 2nd, 2026**. The new versions (`checkout@v5`, `setup-node@v6`, `cache@v5`) all run natively on Node.js 24.

## Affected files

- `.github/workflows/prettier.yml`
- `.github/workflows/codeql-analysis.yml`
- `.github/workflows/nodejs.yml`
- `.github/workflows/npm-release.yml`

## Test plan

- [x] Node.js build workflow passes across all matrix versions (20, 22, 24, 25)
- [x] Codestyle (Prettier) workflow passes
- [x] CodeQL analysis workflow passes
- [x] No deprecation warnings in CI run logs for the upgraded actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)