### PR TITLE
build: replace ts-mocha with mocha + ts-node/register

### DIFF
--- a/.mocharc.cjs
+++ b/.mocharc.cjs
@@ -1,0 +1,6 @@
+process.env.TS_NODE_PROJECT = process.env.TS_NODE_PROJECT || require('path').join(__dirname, 'test/tsconfig.json');
+
+module.exports = {
+  require: ['ts-node/register'],
+  extensions: ['ts'],
+};

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "prepublishOnly": "yarn prettier:lint && yarn build && yarn test:integration",
-    "test": "ts-mocha --recursive test/**/*.spec.ts",
+    "test": "mocha --recursive 'test/**/*.spec.ts'",
     "test:integration": "node test/integration/esm.mjs && node test/integration/cjs.cjs",
     "coverage": "nyc yarn test",
     "build:esm": "tsc --project tsconfig.esm.json && node -e \"require('fs').writeFileSync('dist/esm/package.json', JSON.stringify({type:'module'}))\"",
@@ -48,7 +48,6 @@
     "nyc": "18.0.0",
     "prettier": "3.8.3",
     "source-map-support": "0.5.21",
-    "ts-mocha": "11.1.0",
     "ts-node": "10.9.2",
     "typescript": "6.0.3"
   },


### PR DESCRIPTION
## Summary
- Removes unmaintained `ts-mocha` (last release a year ago; incompatible peer-dep for mocha 11+) and replaces it with direct `mocha` + `ts-node/register` — the same mechanism ts-mocha wraps.
- Adds `.mocharc.cjs` that registers `ts-node` and points `TS_NODE_PROJECT` at `test/tsconfig.json` (which the root tsconfig excludes).
- No change in test behavior: 108/108 tests pass, `yarn coverage` still reports 100%.

## Test plan
- [x] `yarn test` — 108 passing
- [x] `yarn coverage` — 100% statements/branches/functions/lines
- [x] `yarn install` — no peer-dep warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)